### PR TITLE
Removed OTEL_RESOURCE_ATTRIBUTES

### DIFF
--- a/src/digma/Chart.yaml
+++ b/src/digma/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 # version: this Chart version
-version: 1.0.78
+version: 1.0.79
 name: digma
 description: A Helm chart containing Digma's services and dbs
 home: https://github.com/digma-ai/digma
 type: application
 # appVersion: digma version (affects image tag)
-appVersion: 0.2.80
+appVersion: 0.2.81

--- a/src/digma/templates/analytics.yaml
+++ b/src/digma/templates/analytics.yaml
@@ -39,7 +39,5 @@ spec:
 {{ end }}
         - name: OtlpSamplerProbability
           value: {{ .Values.digmaSelfDiagnosis.otlpSamplerProbability| quote}}
-        - name: OTEL_RESOURCE_ATTRIBUTES
-          value: ApplicationVersion={{.Chart.AppVersion}},ChartVersion={{.Chart.Version}}
 
 

--- a/src/digma/templates/collector-api.yaml
+++ b/src/digma/templates/collector-api.yaml
@@ -45,5 +45,3 @@ spec:
 {{ end }}
         - name: OtlpSamplerProbability
           value: {{ .Values.digmaSelfDiagnosis.otlpSamplerProbability| quote}}
-        - name: OTEL_RESOURCE_ATTRIBUTES
-          value: ApplicationVersion={{.Chart.AppVersion}},ChartVersion={{.Chart.Version}}

--- a/src/digma/templates/digma-insight-analysis.yaml
+++ b/src/digma/templates/digma-insight-analysis.yaml
@@ -38,5 +38,3 @@ spec:
         {{- include "env.versions" . | nindent  8 }}
         - name: OtlpSamplerProbability
           value: {{ .Values.digmaSelfDiagnosis.otlpSamplerProbability| quote}}
-        - name: OTEL_RESOURCE_ATTRIBUTES
-          value: ApplicationVersion={{.Chart.AppVersion}},ChartVersion={{.Chart.Version}}

--- a/src/digma/templates/digma-measurement-analysis.yaml
+++ b/src/digma/templates/digma-measurement-analysis.yaml
@@ -38,5 +38,3 @@ spec:
         {{- include "env.versions" . | nindent  8 }}
         - name: OtlpSamplerProbability
           value: {{ .Values.digmaSelfDiagnosis.otlpSamplerProbability| quote}}
-        - name: OTEL_RESOURCE_ATTRIBUTES
-          value: ApplicationVersion={{.Chart.AppVersion}},ChartVersion={{.Chart.Version}}

--- a/src/digma/templates/digma-scheduler.yaml
+++ b/src/digma/templates/digma-scheduler.yaml
@@ -43,7 +43,5 @@ spec:
 {{ end }}
         - name: OtlpSamplerProbability
           value: {{ .Values.digmaSelfDiagnosis.otlpSamplerProbability| quote}}
-        - name: OTEL_RESOURCE_ATTRIBUTES
-          value: ApplicationVersion={{.Chart.AppVersion}},ChartVersion={{.Chart.Version}}
 
 

--- a/src/digma/templates/plugin-api.yaml
+++ b/src/digma/templates/plugin-api.yaml
@@ -47,5 +47,3 @@ spec:
           value: {{ .Values.digmaPluginApi.secured | quote }}
         - name: OtlpSamplerProbability
           value: {{ .Values.digmaSelfDiagnosis.otlpSamplerProbability| quote}}
-        - name: OTEL_RESOURCE_ATTRIBUTES
-          value: ApplicationVersion={{.Chart.AppVersion}},ChartVersion={{.Chart.Version}}


### PR DESCRIPTION
- Upgraded digma services to 0.2.81, which using the new `ApplicationVersion` and `ChartVersion` env vars
- Removed `OTEL_RESOURCE_ATTRIBUTES` env var

See PR #27 and https://github.com/digma-ai/digma-collector-backend/pull/795