### PR TITLE
Added rendered deployment

### DIFF
--- a/src/rendered-deployment.yaml
+++ b/src/rendered-deployment.yaml
@@ -234,9 +234,9 @@ spec:
         - name: GlobalExceptionSettings__ExposeInternalDetails
           value: "false"
         - name: AccessToken
-          value: ${ACCESS_TOKEN}
+          value: "${ACCESS_TOKEN}"
         - name: Analytics.Endpoints__Default__Secured
-          value: ${ANALYTICS_API_SECURED}"
+          value: "${ANALYTICS_API_SECURED}"
         - name: CollectorUrl
           value:  http://digma-collector-api:5049
 ---

--- a/src/rendered-deployment.yaml
+++ b/src/rendered-deployment.yaml
@@ -1,0 +1,886 @@
+---
+# Source: digma/templates/external-network.yaml
+# Comment the following section to only expose plugin api internally
+kind: Service
+apiVersion: v1
+metadata:
+  name: digma-analytics-service-lb
+spec:
+  type: LoadBalancer
+  selector:
+     app: "digma-analytics"
+  ports:
+    - name: analytics
+      protocol: TCP
+      port: 5051
+---
+# Source: digma/templates/external-network.yaml
+# Comment the following section to only expose collector api internally
+kind: Service
+apiVersion: v1
+metadata:
+  name: digma-collector-api-service-lb
+spec:
+  type: LoadBalancer
+  selector:
+     app: "digma-collector-api"
+  ports:
+    - name: http
+      protocol: TCP
+      port: 5049
+    - name: grpc
+      protocol: TCP
+      port: 5050
+---
+# Source: digma/templates/external-network.yaml
+# Comment the following section to only expose jaeger internally
+apiVersion: v1
+kind: Service
+metadata:
+  name: digma-embedded-jaeger-lb
+spec:
+  type: LoadBalancer
+  selector:
+     app: "embedded-jaeger"
+  ports:
+  - name: api
+    port: 17686
+    protocol: TCP
+    targetPort: 16686
+---
+# Source: digma/templates/internal-network.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: digma-kafka
+spec:
+  type: ClusterIP
+  selector:
+     app: kafka
+  ports:
+  - port: 9092
+    protocol: TCP
+---
+# Source: digma/templates/internal-network.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: digma-postgres
+spec:
+  type: ClusterIP
+  selector:
+    app: "postgres"
+  ports:
+  - port: 5432
+    protocol: TCP
+---
+# Source: digma/templates/internal-network.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: digma-redis
+spec:
+  type: ClusterIP
+  selector:
+    app: "redis"
+  ports:
+  - port: 6379
+    protocol: TCP
+---
+# Source: digma/templates/internal-network.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: digma-influxdb
+spec:
+  type: ClusterIP
+  selector:
+    app: "influxdb"
+  ports:
+  - port: 8086
+    protocol: TCP
+---
+# Source: digma/templates/internal-network.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: digma-ds
+spec:
+  type: ClusterIP
+  selector:
+     app: "digma-ds"
+  ports:
+    - name: http
+      protocol: TCP
+      port: 5054
+---
+# Source: digma/templates/internal-network.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: digma-analytics
+spec:
+  type: ClusterIP
+  selector:
+    app: digma-analytics
+  ports:
+  - port: 5051
+    protocol: TCP
+---
+# Source: digma/templates/internal-network.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: digma-scheduler
+spec:
+  type: ClusterIP
+  selector:
+    app: "digma-scheduler"   
+  ports:
+  - port: 5053
+    protocol: TCP
+---
+# Source: digma/templates/internal-network.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: digma-collector-api
+spec:
+  type: ClusterIP
+  selector:
+     app: "digma-collector-api"
+  ports:
+    - name: http
+      protocol: TCP
+      port: 5049
+    - name: grpc
+      protocol: TCP
+      port: 5050
+---
+# Source: digma/templates/internal-network.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: digma-embedded-jaeger
+spec:
+  type: ClusterIP
+  selector:
+     app: "embedded-jaeger"
+  ports:
+  - name: grpc
+    port: 4317
+    protocol: TCP
+  - name: api
+    port: 16686
+    protocol: TCP
+---
+# Source: digma/templates/analytics.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: digma-analytics-deployment
+  labels:
+    app: digma-analytics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: digma-analytics
+  template:
+    metadata:
+      labels:
+        app: digma-analytics
+    spec:
+      containers:
+      - name: digma-analytics
+        image: digmatic/digma-analytics:0.2.236
+        resources:
+          requests:
+            memory: 300Mi
+            cpu: 100m
+          limits:
+            memory: 800Mi
+            cpu: 800m
+        ports:
+        - containerPort: 5051
+        env:
+        - name: DEPLOYMENT_ENV
+          value: 
+        - name: Site
+          value: undefined
+        - name: CacheSettings__RedisConnection
+          value: digma-redis
+        - name: influx2__Url
+          value:  http://digma-influxdb:8086
+        - name: ConnectionStrings__Postgres
+          value:  Server=digma-postgres;Port=5432;Database=digma_analytics;User Id=postgres;Password=postgres;
+        - name: OtlpExporterUrl
+          value: 
+        - name: OtlpExportLogs
+          value: "false"
+        - name: OtlpExportMetrics
+          value: "false"
+        - name: OtlpExportTraces
+          value: "false"
+        - name: ApplicationVersion
+          value: 0.2.236
+        - name: ChartVersion
+          value: 1.0.131
+
+        - name: OtlpSamplerProbability
+          value: "0.3"
+        - name: BACKEND_DEPLOYMENT_TYPE
+          value: "Helm"
+        - name: GlobalExceptionSettings__ExposeInternalDetails
+          value: "false"
+        - name: AccessToken
+          value: ${ACCESS_TOKEN}
+        - name: Analytics.Endpoints__Default__Secured
+          value: ${ANALYTICS_API_SECURED}"
+        - name: CollectorUrl
+          value:  http://digma-collector-api:5049
+---
+# Source: digma/templates/collector-api.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: digma-collector-deployment
+  labels:
+    app: digma-collector-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: digma-collector-api
+  template:
+    metadata:
+      labels:
+        app: digma-collector-api
+    spec:
+      containers:
+      - name: digma-collector-api
+        image: digmatic/digma-collector:0.2.236
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 50m
+          limits:
+            memory: 300Mi
+            cpu: 200m
+        ports:
+        - containerPort: 5049
+        - containerPort: 5050
+        env:
+        - name: DEPLOYMENT_ENV
+          value: 
+        - name: Site
+          value: undefined
+        - name: ConnectionStrings__Postgres
+          value:  Server=digma-postgres;Port=5432;Database=digma_analytics;User Id=postgres;Password=postgres;
+        - name: CacheSettings__RedisConnection
+          value: digma-redis
+        - name: Kafka__Urls__0
+          value: digma-kafka:9092
+        - name: OtlpExporterUrl
+          value: 
+        - name: OtlpExportLogs
+          value: "false"
+        - name: OtlpExportMetrics
+          value: "false"
+        - name: OtlpExportTraces
+          value: "false"
+        - name: ApplicationVersion
+          value: 0.2.236
+        - name: ChartVersion
+          value: 1.0.131
+        - name: Jaeger__OtlpUrl
+          value:  http://digma-embedded-jaeger:4317
+
+        - name: OtlpSamplerProbability
+          value: "0.3"
+        - name: BACKEND_DEPLOYMENT_TYPE
+          value: "Helm"
+---
+# Source: digma/templates/digma-collector-worker.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: digma-digma-collector-worker-deployment
+  labels:
+    app: digma-collector-worker
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: digma-collector-worker
+  template:
+    metadata:
+      labels:
+        app: digma-collector-worker
+    spec:
+      containers:
+      - name: digma-collector-worker
+        image: digmatic/digma-collector-worker:0.2.236
+        resources:
+          requests:
+            memory: 200Mi
+            cpu: 100m
+          limits:
+            memory: 400Mi
+            cpu: 600m
+        env:
+        - name: DEPLOYMENT_ENV
+          value: 
+        - name: Site
+          value: undefined
+        - name: OtlpExporterUrl
+          value: 
+        - name: OtlpExportLogs
+          value: "false"
+        - name: OtlpExportMetrics
+          value: "false"
+        - name: OtlpExportTraces
+          value: "false"
+        - name: CacheSettings__RedisConnection
+          value: digma-redis
+        - name: influx2__Url
+          value:  http://digma-influxdb:8086
+        - name: ConnectionStrings__Postgres
+          value:  Server=digma-postgres;Port=5432;Database=digma_analytics;User Id=postgres;Password=postgres;
+        - name: Kafka__Urls__0
+          value: digma-kafka:9092
+        - name: ApplicationVersion
+          value: 0.2.236
+        - name: ChartVersion
+          value: 1.0.131
+        - name: Jaeger__OtlpUrl
+          value:  http://digma-embedded-jaeger:4317
+        - name: OtlpSamplerProbability
+          value: "0.3"
+        - name: BACKEND_DEPLOYMENT_TYPE
+          value: "Helm"
+        - name: ThresholdOptions__RecentActivityUpdateThresholdSeconds
+          value: "5"
+        - name: ThresholdOptions__UpsertEndpointThresholdSeconds
+          value: "5"
+        - name: ThresholdOptions__UpsertSpansThresholdSeconds
+          value: "5"
+        - name: ThresholdOptions__UpsertSpanFlowMetadataThresholdSeconds
+          value: "5"
+---
+# Source: digma/templates/digma-ds.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: digma-ds-deployment
+  labels:
+    app: digma-ds
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: digma-ds
+  template:
+    metadata:
+      labels:
+        app: digma-ds
+    spec:
+      containers:
+      - name: digma-ds
+        image: digmatic/ds:0.0.22
+        command: ["gunicorn", "-w 4", "--statsd-host=statsd-exporter:9125", "-b 0.0.0.0:5054", "app.main:app"]
+        resources:
+          requests:
+            memory: 300Mi
+            cpu: 100m
+          limits:
+            memory: 500Mi
+            cpu: 700m
+        ports:
+        - containerPort: 5054
+        env:
+        - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+          value: 
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: digma.environment=%!s(<nil>)
+        # - name: OTEL_TRACES_SAMPLER
+        #   value: traceidratio
+        # - name: OTEL_TRACES_SAMPLER_ARG
+        #   value:  "0.3"
+---
+# Source: digma/templates/digma-measurement-analysis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: digma-digma-measurement-analysis-deployment
+  labels:
+    app: digma-measurement-analysis
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: digma-measurement-analysis
+  template:
+    metadata:
+      labels:
+        app: digma-measurement-analysis
+    spec:
+      containers:
+      - name: digma-measurement-analysis
+        image: digmatic/digma-measurement-analysis:0.2.236
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 200m
+          limits:
+            memory: 500Mi
+            cpu: 800m
+        env:
+        - name: DEPLOYMENT_ENV
+          value: 
+        - name: Site
+          value: undefined
+        - name: CacheSettings__RedisConnection
+          value: digma-redis
+        - name: influx2__Url
+          value:  http://digma-influxdb:8086
+        - name: ConnectionStrings__Postgres
+          value:  Server=digma-postgres;Port=5432;Database=digma_analytics;User Id=postgres;Password=postgres;
+        - name: Kafka__Urls__0
+          value: digma-kafka:9092
+        - name: OtlpExporterUrl
+          value: 
+        - name: OtlpExportLogs
+          value: "false"
+        - name: OtlpExportMetrics
+          value: "false"
+        - name: OtlpExportTraces
+          value: "false"
+        - name: ApplicationVersion
+          value: 0.2.236
+        - name: ChartVersion
+          value: 1.0.131
+        - name: Jaeger__OtlpUrl
+          value:  http://digma-embedded-jaeger:4317
+        - name: OtlpSamplerProbability
+          value: "0.3"
+        - name: BACKEND_DEPLOYMENT_TYPE
+          value: "Helm"
+        - name: Kafka__SpanDurationSummaryCG__Workers
+          value: '2'
+        - name: Kafka__SpanDurationTotalCG__Workers
+          value: '2'
+        - name: Kafka__SpanUsageStatsCG__Workers
+          value: '2'
+        - name: Kafka__BottleneckCG__Workers
+          value: '2'
+        - name: Kafka__SpanDurationSummaryCG__WorkerBatchSize
+          value: '1000'
+        - name: Kafka__SpanDurationTotalCG__WorkerBatchSize
+          value: '1000'
+        - name: Kafka__SpanUsageStatsCG__WorkerBatchSize
+          value: '1000'
+        - name: Kafka__BottleneckCG__WorkerBatchSize
+          value: '1000'
+        - name: Kafka__SpanMeasurementsProcessorCG__WorkerBatchSize
+          value: '1000'
+---
+# Source: digma/templates/digma-pipeline-worker.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: digma-digma-pipeline-worker-deployment
+  labels:
+    app: digma-pipeline-worker
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: digma-pipeline-worker
+  template:
+    metadata:
+      labels:
+        app: digma-pipeline-worker
+    spec:
+      containers:
+      - name: digma-pipeline-worker
+        image: digmatic/digma-pipeline-worker:0.2.236
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 50m
+          limits:
+            memory: 300Mi
+            cpu: 500m
+        env:
+        - name: DEPLOYMENT_ENV
+          value: 
+        - name: Site
+          value: undefined
+        - name: OtlpExporterUrl
+          value: 
+        - name: OtlpExportLogs
+          value: "false"
+        - name: OtlpExportMetrics
+          value: "false"
+        - name: OtlpExportTraces
+          value: "false"
+        - name: CacheSettings__RedisConnection
+          value: digma-redis
+        - name: influx2__Url
+          value:  http://digma-influxdb:8086
+        - name: ConnectionStrings__Postgres
+          value:  Server=digma-postgres;Port=5432;Database=digma_analytics;User Id=postgres;Password=postgres;
+        - name: Kafka__Urls__0
+          value: digma-kafka:9092
+        - name: ApplicationVersion
+          value: 0.2.236
+        - name: ChartVersion
+          value: 1.0.131
+        - name: Jaeger__OtlpUrl
+          value:  http://digma-embedded-jaeger:4317
+        - name: OtlpSamplerProbability
+          value: "0.3"
+        - name: BACKEND_DEPLOYMENT_TYPE
+          value: "Helm"
+        - name: Ds__Url
+          value: http://digma-ds:5054
+---
+# Source: digma/templates/digma-scheduler.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: digma-digma-scheduler-deployment
+  labels:
+    app: digma-scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: digma-scheduler
+  template:
+    metadata:
+      labels:
+        app: digma-scheduler
+    spec:
+      containers:
+      - name: digma-scheduler
+        image: digmatic/digma-scheduler:0.2.236
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 50m
+          limits:
+            memory: 300Mi
+            cpu: 300m
+        ports:
+        - containerPort: 5053
+        env:
+        - name: DEPLOYMENT_ENV
+          value: 
+        - name: Site
+          value: undefined
+        - name: CacheSettings__RedisConnection
+          value: digma-redis
+        - name: influx2__Url
+          value:  http://digma-influxdb:8086
+        - name: ConnectionStrings__Postgres
+          value:  Server=digma-postgres;Port=5432;Database=digma_analytics;User Id=postgres;Password=postgres;
+        - name: Kafka__Urls__0
+          value: digma-kafka:9092
+        - name: OtlpExporterUrl
+          value: 
+        - name: OtlpExportLogs
+          value: "false"
+        - name: OtlpExportMetrics
+          value: "false"
+        - name: OtlpExportTraces
+          value: "false"
+        - name: ApplicationVersion
+          value: 0.2.236
+        - name: ChartVersion
+          value: 1.0.131
+
+        - name: OtlpSamplerProbability
+          value: "0.3"
+        - name: BACKEND_DEPLOYMENT_TYPE
+          value: "Helm"
+---
+# Source: digma/templates/embedded-jaeger.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: digma-embedded-jaeger-stateful-set
+  labels:
+    app: embedded-jaeger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: embedded-jaeger
+  serviceName: digma-embedded-jaeger
+  template:
+    metadata:
+      labels:
+        app: embedded-jaeger
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: embedded-jaeger
+        image: jaegertracing/all-in-one:1.44.0
+        args: ["--query.additional-headers", "Access-Control-Allow-Origin: *"]
+        env:
+        - name: SPAN_STORAGE_TYPE
+          value: badger
+        - name: COLLECTOR_OTLP_ENABLED
+          value: "true" # enable OTEL receiver
+        - name: BADGER_EPHEMERAL
+          value: "false"
+        - name: BADGER_DIRECTORY_VALUE
+          value: "/badger/data"
+        - name: BADGER_DIRECTORY_KEY
+          value: "/badger/key"
+        - name: BADGER_SPAN_STORE_TTL
+          value: "336h0m0s" # BADGER store ttl default is 72h
+---
+# Source: digma/templates/influxdb.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: digma-influxdb-stateful-set
+  labels:
+    app: influxdb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: influxdb
+  serviceName: digma-influxdb
+  template:
+    metadata:
+      labels:
+        app: influxdb
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: influxdb
+        image: influxdb:2.7.1
+        resources:
+          requests:
+            memory: 500Mi
+            cpu: 500m
+          limits:
+            memory: 2Gi
+            cpu: 2000m
+        ports:
+          - containerPort: 8086
+        env:
+        - name: DOCKER_INFLUXDB_INIT_MODE
+          value: "setup"
+        - name: DOCKER_INFLUXDB_INIT_USERNAME
+          value: "admin"
+        - name: DOCKER_INFLUXDB_INIT_PASSWORD
+          value: "12345678"
+        - name: DOCKER_INFLUXDB_INIT_ORG
+          value: "digma"
+        - name: DOCKER_INFLUXDB_INIT_BUCKET
+          value: "errors"
+        - name: DOCKER_INFLUXDB_INIT_RETENTION
+          value: "4w"
+        - name: DOCKER_INFLUXDB_INIT_ADMIN_TOKEN
+          value: "dc61908e-05bc-411a-9fe2-e3356b8dc7c0"
+        - name: INFLUXD_QUERY_CONCURRENCY
+          value: "30"
+        - name: INFLUXD_QUERY_QUEUE_SIZE
+          value: "200"
+        volumeMounts:
+        - name: influxdb-data
+          mountPath: /var/lib/influxdb2
+        - name: influxdb-data
+          mountPath: /etc/influxdb2
+  volumeClaimTemplates:
+    - metadata:
+        name: influxdb-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50Gi
+  # persistentVolumeClaimRetentionPolicy:
+  #   whenDeleted: Retain
+---
+# Source: digma/templates/kafka.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: digma-kafka-stateful-set
+  labels:
+    app: kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  serviceName: digma-kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1001
+      containers:
+      - name: kafka
+        image: bitnami/kafka:3.5.1
+        resources:
+          requests:
+            memory: 400Mi
+            cpu: 200m
+          limits:
+            memory: 3Gi
+            cpu: 1000m
+        ports:
+        - containerPort: 9092
+        volumeMounts: 
+        - name: kafka-data
+          mountPath: /bitnami/kafka
+        env:
+        # KRaft settings
+        - name: KAFKA_KRAFT_CLUSTER_ID
+          value: h4U35I9QRnGhbgsEQAlXAw
+        - name: KAFKA_CFG_NODE_ID
+          value: "1"
+        - name: KAFKA_CFG_PROCESS_ROLES
+          value: controller,broker
+        - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
+          value: 1@127.0.0.1:9093
+        # Listeners
+        - name: KAFKA_CFG_LISTENERS
+          value: PLAINTEXT://:9092,CONTROLLER://:9093
+        - name: KAFKA_CFG_ADVERTISED_LISTENERS
+          value: PLAINTEXT://digma-kafka:9092
+        - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
+          value: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,INTERNAL:PLAINTEXT
+        - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
+          value: CONTROLLER
+        - name: KAFKA_CFG_INTER_BROKER_LISTENER_NAME
+          value: PLAINTEXT
+        # Retention
+        - name: KAFKA_CFG_LOG_RETENTION_MINUTES
+          value: "30"
+        - name: KAFKA_CFG_LOG_RETENTION_CHECK_INTERVAL_MS
+          value: "300000" # 5 min
+        - name: KAFKA_CFG_LOG_ROLL_MS
+          value: "600000" # 10 min
+  volumeClaimTemplates:
+  - metadata:
+      name: kafka-data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+---
+# Source: digma/templates/postgres.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: digma-postgres-stateful-set
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  serviceName: digma-postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: postgres
+        image: postgres:15.1
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 200m
+          limits:
+            memory: 2Gi
+            cpu: 1000m
+        ports:
+          - containerPort: 5432
+        args: ["-c" ,"max_connections=400", "-c", "shared_buffers=800MB", "-c", "logging_collector=on", "-c","log_directory=log"]
+        env:
+        - name: POSTGRES_NAME
+          value: postgres
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_PASSWORD
+          value: postgres
+        volumeMounts:
+        - name: postgres-data
+          mountPath: /var/lib/postgresql/data
+          subPath: postgres
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+  # persistentVolumeClaimRetentionPolicy:
+  #   whenDeleted: Retain
+---
+# Source: digma/templates/redis.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: digma-redis-stateful-set
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  serviceName: digma-redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: redis
+          image: redis:7.0.5-alpine
+          resources:
+            requests:
+              memory: 100Mi
+              cpu: 50m
+            limits:
+              memory: 2Gi
+              cpu: 400m
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+  # persistentVolumeClaimRetentionPolicy:
+  #   whenDeleted: Retain

--- a/src/rendered-deployment.yaml
+++ b/src/rendered-deployment.yaml
@@ -225,7 +225,7 @@ spec:
         - name: ApplicationVersion
           value: 0.2.236
         - name: ChartVersion
-          value: 1.0.131
+          value: 1.0.132
 
         - name: OtlpSamplerProbability
           value: "0.3"
@@ -292,7 +292,7 @@ spec:
         - name: ApplicationVersion
           value: 0.2.236
         - name: ChartVersion
-          value: 1.0.131
+          value: 1.0.132
         - name: Jaeger__OtlpUrl
           value:  http://digma-embedded-jaeger:4317
 
@@ -352,7 +352,7 @@ spec:
         - name: ApplicationVersion
           value: 0.2.236
         - name: ChartVersion
-          value: 1.0.131
+          value: 1.0.132
         - name: Jaeger__OtlpUrl
           value:  http://digma-embedded-jaeger:4317
         - name: OtlpSamplerProbability
@@ -459,7 +459,7 @@ spec:
         - name: ApplicationVersion
           value: 0.2.236
         - name: ChartVersion
-          value: 1.0.131
+          value: 1.0.132
         - name: Jaeger__OtlpUrl
           value:  http://digma-embedded-jaeger:4317
         - name: OtlpSamplerProbability
@@ -493,7 +493,7 @@ metadata:
   labels:
     app: digma-pipeline-worker
 spec:
-  replicas: 4
+  replicas: 1
   selector:
     matchLabels:
       app: digma-pipeline-worker
@@ -536,7 +536,7 @@ spec:
         - name: ApplicationVersion
           value: 0.2.236
         - name: ChartVersion
-          value: 1.0.131
+          value: 1.0.132
         - name: Jaeger__OtlpUrl
           value:  http://digma-embedded-jaeger:4317
         - name: OtlpSamplerProbability
@@ -599,7 +599,7 @@ spec:
         - name: ApplicationVersion
           value: 0.2.236
         - name: ChartVersion
-          value: 1.0.131
+          value: 1.0.132
 
         - name: OtlpSamplerProbability
           value: "0.3"
@@ -769,11 +769,11 @@ spec:
           value: PLAINTEXT
         # Retention
         - name: KAFKA_CFG_LOG_RETENTION_MINUTES
-          value: "30"
+          value: "20"
         - name: KAFKA_CFG_LOG_RETENTION_CHECK_INTERVAL_MS
-          value: "300000" # 5 min
+          value: "100000" # 1 min
         - name: KAFKA_CFG_LOG_ROLL_MS
-          value: "600000" # 10 min
+          value: "500000" # 5 min
   volumeClaimTemplates:
   - metadata:
       name: kafka-data
@@ -782,7 +782,7 @@ spec:
         - ReadWriteOnce
       resources:
         requests:
-          storage: 10Gi
+          storage: 15Gi
 ---
 # Source: digma/templates/postgres.yaml
 apiVersion: apps/v1


### PR DESCRIPTION
Placeholders:
- `${ACCESS_TOKEN}`
- `${ANALYTICS_API_SECURED}`

Inplace instructions:
- `# Comment the following section to only expose collector api internally`
- `# Comment the following section to only expose plugin api internally`
- `# Comment the following section to only expose jaeger internally`

How to update:
1. Run:
```
helm template digma . --set digmaAnalytics.accesstoken=abc --set size=medium --set digmaCollectorApi.expose=true --set digmaAnalytics.expose=true --set embeddedJaeger.enabled=true --set embeddedJaeger.expose=true > rendered.yaml
```
2. Access the file 
3. Before the `digma-analytics-service-lb` deployment add the comment:
```
# Comment the following section to only expose plugin api internally
```
4. Before the `digma-collector-service-lb` deployment add the comment:
```
# Comment the following section to only expose collector api internally
```
5. Before the `digma-embedded-jaeger-lb` deployment add the comment:
```
# Comment the following section to only expose jaeger internally
```
6. Replace `abs` with `"${ACCESS_TOKEN}"`
7. Find `Analytics.Endpoints__Default__Secured` replace its (`"true"`) value with `"${ANALYTICS_API_SECURED}"`